### PR TITLE
Luke/feat card order

### DIFF
--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -13,12 +13,10 @@
 
     <div class="w-1/8">
 
-      <% if action_name == "new" || "edit"%>
+      <% if action_name == "new"%>
         <%= f.text_field :order, readonly:'', required: true, value: @board.cards.length, class: 'shadow appearance-none border rounded w-16 text-center py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-200' %>
       <% else %>
-        <span class=" block bg-gray-200 appearance-none border rounded w-auto mr-7 py-2 px-8 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-          <%= @card.order%>
-        </span>
+        <%= f.text_field :order, readonly:'', required: true, value: @card.order, class: 'shadow appearance-none border rounded w-16 text-center py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-200' %>
       <% end %>
       </div>
 

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -13,11 +13,10 @@
 
     <div class="w-1/8">
 
-      <% if action_name == "new" || "edit"%>
+      <% if action_name == "new"%>
         <%= f.text_field :order, readonly:'', required: true, value: @board.cards.length, class: 'shadow appearance-none border rounded w-16 text-center py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-200' %>
       <% else %>
-        <span class=" block bg-gray-200 appearance-none border rounded w-auto mr-7 py-2 px-8 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
-          <%= @card.order%>
+        <%= f.text_field :order, readonly:'', required: true, value: @card.order, class: 'shadow appearance-none border rounded w-16 text-center py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-200' %>
         </span>
       <% end %>
       </div>


### PR DESCRIPTION
- fixbug: 編輯卡片時，order的排序正常顯示&依原order做排序

<img width="1032" alt="螢幕快照 2020-05-27 16 20 51" src="https://user-images.githubusercontent.com/58649843/82995555-500e1600-a036-11ea-9b50-f1cfd484ca9c.png">
